### PR TITLE
Tests to improve code coverage for command.standard

### DIFF
--- a/src/org/extendedCLI/command/standard/History.java
+++ b/src/org/extendedCLI/command/standard/History.java
@@ -11,8 +11,10 @@ import org.extendedCLI.command.Command;
 import org.extendedCLI.command.ExtendedCommandLine;
 
 @SuppressWarnings("javadoc")
-public class History extends AbstractCommand{
-	
+public class History extends AbstractCommand {
+
+	public static final String NO_COMMANDS_STRING = "No commands yet.";
+
 	private final Map<Long, Command> history;
 
 	public History(Map<Long, Command> history) {
@@ -22,11 +24,11 @@ public class History extends AbstractCommand{
 
 	@Override
 	protected void execute(ExtendedCommandLine commandLine) {
-		if(history.isEmpty()){
-			System.out.println("No commands yet.");
+		if(history.isEmpty()) {
+			System.out.println(NO_COMMANDS_STRING);
 		}
-		else{
-			for(long date : history.keySet()){
+		else {
+			for(long date : history.keySet()) {
 				System.out.println(LocalDateTime.ofInstant(Instant.ofEpochMilli(date), ZoneId.systemDefault()) + " -> " + history.get(date));
 			}
 		}

--- a/test/org/extendedCLI/test/command/standard/ExitTest.java
+++ b/test/org/extendedCLI/test/command/standard/ExitTest.java
@@ -1,0 +1,26 @@
+package org.extendedCLI.test.command.standard;
+
+import org.extendedCLI.command.standard.Exit;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ExitTest {
+    private Exit testExit = new Exit();
+
+    @Test
+    public void testDescription() {
+        assertThat(testExit.getDescription(), containsString("system gracefully"));
+    }
+
+    @Test
+    public void testUndo() {
+        Exit spy = Mockito.spy(testExit);
+        spy.undo();
+        verify(spy, times(1)).undo();
+    }
+}

--- a/test/org/extendedCLI/test/command/standard/HelpTest.java
+++ b/test/org/extendedCLI/test/command/standard/HelpTest.java
@@ -1,0 +1,74 @@
+package org.extendedCLI.test.command.standard;
+
+import org.extendedCLI.argument.Arguments;
+import org.extendedCLI.command.AbstractCommand;
+import org.extendedCLI.command.Command;
+import org.extendedCLI.command.ExtendedCommandLine;
+import org.extendedCLI.command.standard.Help;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class HelpTest {
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    private Map<String, Command> commands = new LinkedHashMap<>();
+    private Help testHelp = new Help(commands);
+
+    @Before
+    public void setup() {
+        System.setOut(new PrintStream(outputStream));
+        commands = new LinkedHashMap<>();
+        testHelp = new Help(commands);
+    }
+
+    @After
+    public void cleanup() {
+        System.setOut(null);
+    }
+
+    @Test
+    public void testDescription() {
+        assertThat(testHelp.getDescription(), containsString("command list documentation"));
+    }
+
+    @Test
+    public void testExecute() {
+        Command coffeeCommand = new AbstractCommand(Arguments.empty()) {
+            @Override
+            public void undo() {
+
+            }
+
+            @Override
+            protected void execute(ExtendedCommandLine commandLine) {
+
+            }
+        };
+        coffeeCommand.setDescription("I make coffee");
+
+        commands.put("COFFEE", coffeeCommand);
+        testHelp = new Help(commands);
+        testHelp.execute("bogusValue");
+
+        assertThat(outputStream.toString(), containsString("I make coffee"));
+    }
+
+    @Test
+    public void testUndo() {
+        Help spy = Mockito.spy(testHelp);
+        spy.undo();
+        verify(spy, times(1)).undo();
+    }
+}

--- a/test/org/extendedCLI/test/command/standard/HistoryTest.java
+++ b/test/org/extendedCLI/test/command/standard/HistoryTest.java
@@ -37,7 +37,7 @@ public class HistoryTest {
     }
 
     @Test
-    public void testHistoryDescription() {
+    public void testDescription() {
         assertThat(testHistory.getDescription(), containsString("history with timestamps"));
     }
 

--- a/test/org/extendedCLI/test/command/standard/HistoryTest.java
+++ b/test/org/extendedCLI/test/command/standard/HistoryTest.java
@@ -1,0 +1,70 @@
+package org.extendedCLI.test.command.standard;
+
+import org.extendedCLI.command.Command;
+import org.extendedCLI.command.standard.History;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.countMatches;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class HistoryTest {
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    private Map<Long, Command> commandHistory;
+    private History testHistory;
+
+    @Before
+    public void setup() {
+        System.setOut(new PrintStream(outputStream));
+        commandHistory = new LinkedHashMap<>();
+        testHistory = new History(commandHistory);
+    }
+
+    @After
+    public void cleanup() {
+        System.setOut(null);
+    }
+
+    @Test
+    public void testHistoryDescription() {
+        assertThat(testHistory.getDescription(), containsString("history with timestamps"));
+    }
+
+    @Test
+    public void testEmptyHistory() {
+        testHistory.execute("bogusValue");
+        assertThat(outputStream.toString(), containsString(History.NO_COMMANDS_STRING));
+    }
+
+    @Test
+    public void testSomeHistory() {
+        long timeOffset = 888888L;
+        Command mockCommand =  mock(Command.class);
+
+        commandHistory.put(System.currentTimeMillis(), mockCommand);
+        commandHistory.put(System.currentTimeMillis() + timeOffset, mockCommand);
+
+        testHistory = new History(commandHistory);
+        testHistory.execute("bogusValue");
+
+        assertEquals(2, countMatches(outputStream.toString(), "->"));
+    }
+
+    @Test
+    public void testUndo() {
+        History spy = Mockito.spy(testHistory);
+        spy.undo();
+        verify(spy, times(1)).undo();
+    }
+}


### PR DESCRIPTION
Add tests for History, Help, and Exit to improve code coverage. Add a few spaces to make blocks more consistent with the other code (as far as I can tell).

I tried to add a test for System.exit() in Exit.excute using either a Spy or modifying the SecurityManager, but the System.exit() line was never called, so backed out of that.