### PR TITLE
Improve AbstractCommand test coverage

### DIFF
--- a/test/org/extendedCLI/command/AbstractCommandTest.java
+++ b/test/org/extendedCLI/command/AbstractCommandTest.java
@@ -1,0 +1,39 @@
+package org.extendedCLI.command;
+
+import org.extendedCLI.argument.Arguments;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class AbstractCommandTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullInputAdapter() {
+        new AbstractCommand(mock(Arguments.class)) {
+            @Override
+            public void undo() {
+
+            }
+
+            @Override
+            protected void execute(ExtendedCommandLine commandLine) {
+
+            }
+        }.setInputAdapter(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullOutputAdapter() {
+        new AbstractCommand(mock(Arguments.class)) {
+            @Override
+            public void undo() {
+
+            }
+
+            @Override
+            protected void execute(ExtendedCommandLine commandLine) {
+
+            }
+        }.setOutputAdapter(null);
+    }
+}


### PR DESCRIPTION
Asserts the null input of 2 setters.