### PR TITLE
name == null never reached (constructor avoids null names)

### DIFF
--- a/src/org/extendedCLI/argument/DefaultArgument.java
+++ b/src/org/extendedCLI/argument/DefaultArgument.java
@@ -157,10 +157,8 @@ class DefaultArgument implements Argument {
 			return false;
 		}
 		DefaultArgument other = (DefaultArgument) obj;
-		if (!name.equals(other.name)) {
-			return false;
-		}
-		return true;
+
+		return name.equals(other.name);
 	}
 	
 	@Override

--- a/src/org/extendedCLI/argument/DefaultArgument.java
+++ b/src/org/extendedCLI/argument/DefaultArgument.java
@@ -157,11 +157,7 @@ class DefaultArgument implements Argument {
 			return false;
 		}
 		DefaultArgument other = (DefaultArgument) obj;
-		if (name == null) {
-			if (other.name != null) {
-				return false;
-			}
-		} else if (!name.equals(other.name)) {
+		if (!name.equals(other.name)) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Constructor does not allow name to be null (check org.extendedCLI.argument.DefaultArgument#checkValidName) then the true branch for the next condition will never be reached

![screenshot from 2017-10-23 06-11-46](https://user-images.githubusercontent.com/70292/31882136-35a86dac-b7bc-11e7-91c5-c3219f835e72.png)

Also raises coverage (issue #1) as a side effect
